### PR TITLE
use u5 for mode3 color values

### DIFF
--- a/GBA/core.zig
+++ b/GBA/core.zig
@@ -157,8 +157,8 @@ pub const GBA = struct {
         }
     };
 
-    pub fn toNativeColor(red: u8, green: u8, blue: u8) callconv(.Inline) u16 {
-        return @as(u16, red & 0x1f) | (@as(u16, green & 0x1f) << 5) | (@as(u16, blue & 0x1f) << 10);
+    pub fn toNativeColor(red: u5, green: u5, blue: u5) callconv(.Inline) u16 {
+        return @as(u16, red) | (@as(u16, green) << 5) | (@as(u16, blue) << 10);
     }
 
     // TODO: maybe put this in IWRAM ?

--- a/examples/mode3draw/mode3draw.zig
+++ b/examples/mode3draw/mode3draw.zig
@@ -30,15 +30,15 @@ pub fn main() noreturn {
     // Lines in top right frame
     while (i <= 8) : (i += 1) {
         j = 3 * i + 7;
-        Mode3.line(132 + 11 * i, 9, 226, 12 + 7 * i, GBA.toNativeColor(@intCast(u8, j), 0, @intCast(u8, j)));
-        Mode3.line(226 - 11 * i, 70, 133, 69 - 7 * i, GBA.toNativeColor(@intCast(u8, j), 0, @intCast(u8, j)));
+        Mode3.line(132 + 11 * i, 9, 226, 12 + 7 * i, GBA.toNativeColor(@intCast(u5, j), 0, @intCast(u5, j)));
+        Mode3.line(226 - 11 * i, 70, 133, 69 - 7 * i, GBA.toNativeColor(@intCast(u5, j), 0, @intCast(u5, j)));
     }
 
     // Lines in bottom left frame
     i = 0;
     while (i <= 8) : (i += 1) {
         j = 3 * i + 7;
-        Mode3.line(15 + 11 * i, 88, 104 - 11 * i, 150, GBA.toNativeColor(0, @intCast(u8, j), @intCast(u8, j)));
+        Mode3.line(15 + 11 * i, 88, 104 - 11 * i, 150, GBA.toNativeColor(0, @intCast(u5, j), @intCast(u5, j)));
     }
 
     while (true) {}


### PR DESCRIPTION
This makes for catching more errors at comptime, because if a color value is comptime known then values out of range will not be compile errors.

This code change does not seem to affect binary output when building with `zig build`.  I verified using `sha256sum`.