### PR TITLE
Add timer API

### DIFF
--- a/GBA/builder.zig
+++ b/GBA/builder.zig
@@ -37,7 +37,7 @@ pub fn addGBAStaticLibrary(b: *std.Build, lib_name: []const u8, source_file: []c
         .optimize = if (debug) .Debug else .ReleaseFast,
     });
 
-    lib.setLinkerScriptPath(.{ .src_path = .{ .owner = b, .sub_path = gba_linker_script } });
+    lib.setLinkerScript(.{ .src_path = .{ .owner = b, .sub_path = gba_linker_script } });
 
     return lib;
 }
@@ -66,7 +66,7 @@ pub fn addGBAExecutable(b: *std.Build, rom_name: []const u8, source_file: []cons
         .optimize = if (debug) .Debug else .ReleaseFast,
     });
 
-    exe.setLinkerScriptPath(.{ .src_path = .{ .owner = b, .sub_path = gba_linker_script } });
+    exe.setLinkerScript(.{ .src_path = .{ .owner = b, .sub_path = gba_linker_script } });
     if (use_gdb) {
         b.installArtifact(exe);
     } else {
@@ -74,7 +74,7 @@ pub fn addGBAExecutable(b: *std.Build, rom_name: []const u8, source_file: []cons
             .format = .bin,
         });
 
-        const install_bin_step = b.addInstallBinFile(objcopy_step.getOutputSource(), b.fmt("{s}.gba", .{rom_name}));
+        const install_bin_step = b.addInstallBinFile(objcopy_step.getOutput(), b.fmt("{s}.gba", .{rom_name}));
         install_bin_step.step.dependOn(&objcopy_step.step);
 
         b.default_step.dependOn(&install_bin_step.step);

--- a/GBA/gba.zig
+++ b/GBA/gba.zig
@@ -13,7 +13,7 @@ pub const interrupt = @import("interrupt.zig");
 pub const math = @import("math.zig");
 pub const mem = @import("mem.zig");
 pub const obj = @import("obj.zig");
-pub const timer = @import("timer.zig").timer;
+pub const timer = @import("timer.zig");
 pub const utils = @import("utils.zig");
 
 pub const ewram: *volatile [0x20000]u16 = @ptrFromInt(gba.mem.ewram);

--- a/GBA/gba.zig
+++ b/GBA/gba.zig
@@ -13,6 +13,7 @@ pub const interrupt = @import("interrupt.zig");
 pub const math = @import("math.zig");
 pub const mem = @import("mem.zig");
 pub const obj = @import("obj.zig");
+pub const timer = @import("timer.zig");
 pub const utils = @import("utils.zig");
 
 pub const ewram: *volatile [0x20000]u16 = @ptrFromInt(gba.mem.ewram);

--- a/GBA/gba.zig
+++ b/GBA/gba.zig
@@ -13,7 +13,7 @@ pub const interrupt = @import("interrupt.zig");
 pub const math = @import("math.zig");
 pub const mem = @import("mem.zig");
 pub const obj = @import("obj.zig");
-pub const timer = @import("timer.zig");
+pub const timer = @import("timer.zig").timer;
 pub const utils = @import("utils.zig");
 
 pub const ewram: *volatile [0x20000]u16 = @ptrFromInt(gba.mem.ewram);

--- a/GBA/timer.zig
+++ b/GBA/timer.zig
@@ -43,7 +43,7 @@ pub const Timer = packed struct(u32) {
     /// Reading this register gives a timer's current elapsed intervals.
     /// Writing to this register does NOT set the current timer value.
     /// It sets the INITIAL timer value for the next timer run.
-    data: u16,
+    counter: u16,
     
     /// Corresponds to tonc REG_TMxCNT.
     ctrl: Timer.Control,

--- a/GBA/timer.zig
+++ b/GBA/timer.zig
@@ -1,70 +1,52 @@
 const std = @import("std");
 const gba = @import("gba.zig");
 const Enable = gba.utils.Enable;
-const timer = @This();
 
-/// Enumeration of recognized timer tick frequencies.
-pub const Frequency = enum(u2) {
-    /// One timer tick per clock cycle.
-    /// Equivalent to 1/16777216th second, or approximately 0.06 nanoseconds.
-    cycles_1 = 0,
-    /// One timer tick per 64 clock cycles.
-    /// Equivalent to 1/262144th second, or approximately 3.8 nanoseconds.
-    cycles_64 = 1,
-    /// One timer tick per 256 clock cycles.
-    /// Equivalent to 1/65536th second, or approximately 15 nanoseconds.
-    cycles_256 = 2,
-    /// One timer tick per 1024 clock cycles.
-    /// Equivalent to 1/16384th second, or approximately 61 nanoseconds.
-    cycles_1024 = 3,
+/// Encapsulates access to REG_TMxD and REG_TMxCNT registers
+/// for controlling and reading one of the GBA's four timers.
+pub const Timer = packed struct(u32) {
+    /// Enumeration of recognized timer tick frequencies.
+    pub const Frequency = enum(u2) {
+        /// One timer tick per clock cycle.
+        /// Equivalent to 1/16777216th second, or approximately 0.06 microseconds.
+        cycles_1 = 0,
+        /// One timer tick per 64 clock cycles.
+        /// Equivalent to 1/262144th second, or approximately 3.8 microseconds.
+        cycles_64 = 1,
+        /// One timer tick per 256 clock cycles.
+        /// Equivalent to 1/65536th second, or approximately 15 microseconds.
+        cycles_256 = 2,
+        /// One timer tick per 1024 clock cycles.
+        /// Equivalent to 1/16384th second, or approximately 61 microseconds.
+        cycles_1024 = 3,
+    };
+
+    /// Represents the data of a REG_TMxCNT timer control register.
+    pub const Control = packed struct(u16) {
+        /// Timer frequency.
+        /// One second is equivalent to 1024 * 0x4000 clock cycles.
+        freq: Timer.Frequency = .cycles_1,
+        /// Cascade mode. When this bit is set, this timer will be incremented
+        /// when the previous timer overflows. (The timer must also be enabled.)
+        cascade: Enable = .disable,
+        /// Unused bits.
+        unused_1: u3 = 0,
+        /// Raise an interrupt upon overflow.
+        interrupt: Enable = .disable,
+        /// Enable the timer.
+        enable: Enable = .disable,
+        /// Unused bits.
+        unused_2: u8 = 0,
+    };
+    
+    /// Corresponds to tonc REG_TMxD.
+    /// Reading this register gives a timer's current elapsed intervals.
+    /// Writing to this register does NOT set the current timer value.
+    /// It sets the INITIAL timer value for the next timer run.
+    data: u16,
+    
+    /// Corresponds to tonc REG_TMxCNT.
+    ctrl: Timer.Control,
 };
 
-/// Represents the data of a REG_TMxCNT timer control register.
-pub const Control = packed struct(u16) {
-    /// Timer frequency.
-    /// One second is equivalent to 1024 * 0x4000 clock cycles.
-    freq: Frequency = .cycles_1,
-    /// Cascade mode. When this bit is set, this timer will be incremented
-    /// when the previous timer overflows. (The timer must also be enabled.)
-    cascade: Enable = .disable,
-    /// Unused bits.
-    unused_1: u3 = 0,
-    /// Raise an interrupt upon overflow.
-    interrupt: Enable = .disable,
-    /// Enable the timer.
-    enable: Enable = .disable,
-    /// Unused bits.
-    unused_2: u8 = 0,
-};
-
-/// Corresponds to tonc REG_TM1D.
-/// Writing to this register does NOT set the current timer value.
-/// It sets the INITIAL timer value for the next timer run.
-pub const data_1: *volatile u16 = @ptrFromInt(gba.mem.io + 0x100);
-
-/// Corresponds to tonc REG_TM1CNT.
-pub const ctrl_1: *volatile timer.Control = @ptrFromInt(gba.mem.io + 0x102);
-
-/// Corresponds to tonc REG_TM2D.
-/// Writing to this register does NOT set the current timer value.
-/// It sets the INITIAL timer value for the next timer run.
-pub const data_2: *volatile u16 = @ptrFromInt(gba.mem.io + 0x104);
-
-/// Corresponds to tonc REG_TM2CNT.
-pub const ctrl_2: *volatile timer.Control = @ptrFromInt(gba.mem.io + 0x106);
-
-/// Corresponds to tonc REG_TM3D.
-/// Writing to this register does NOT set the current timer value.
-/// It sets the INITIAL timer value for the next timer run.
-pub const data_3: *volatile u16 = @ptrFromInt(gba.mem.io + 0x108);
-
-/// Corresponds to tonc REG_TM3CNT.
-pub const ctrl_3: *volatile timer.Control = @ptrFromInt(gba.mem.io + 0x10a);
-
-/// Corresponds to tonc REG_TM4D.
-/// Writing to this register does NOT set the current timer value.
-/// It sets the INITIAL timer value for the next timer run.
-pub const data_4: *volatile u16 = @ptrFromInt(gba.mem.io + 0x10c);
-
-/// Corresponds to tonc REG_TM4CNT.
-pub const ctrl_4: *volatile timer.Control = @ptrFromInt(gba.mem.io + 0x10e);
+pub const timer: *volatile [4]Timer align(4) = @ptrFromInt(gba.mem.io + 0x100);

--- a/GBA/timer.zig
+++ b/GBA/timer.zig
@@ -1,0 +1,70 @@
+const std = @import("std");
+const gba = @import("gba.zig");
+const Enable = gba.utils.Enable;
+const timer = @This();
+
+/// Enumeration of recognized timer tick frequencies.
+pub const Frequency = enum(u2) {
+    /// One timer tick per clock cycle.
+    /// Equivalent to 1/16777216th second, or approximately 0.06 nanoseconds.
+    cycles_1 = 0,
+    /// One timer tick per 64 clock cycles.
+    /// Equivalent to 1/262144th second, or approximately 3.8 nanoseconds.
+    cycles_64 = 1,
+    /// One timer tick per 256 clock cycles.
+    /// Equivalent to 1/65536th second, or approximately 15 nanoseconds.
+    cycles_256 = 2,
+    /// One timer tick per 1024 clock cycles.
+    /// Equivalent to 1/16384th second, or approximately 61 nanoseconds.
+    cycles_1024 = 3,
+};
+
+/// Represents the data of a REG_TMxCNT timer control register.
+pub const Control = packed struct(u16) {
+    /// Timer frequency.
+    /// One second is equivalent to 1024 * 0x4000 clock cycles.
+    freq: Frequency = .cycles_1,
+    /// Cascade mode. When this bit is set, this timer will be incremented
+    /// when the previous timer overflows. (The timer must also be enabled.)
+    cascade: Enable = .disable,
+    /// Unused bits.
+    unused_1: u3 = 0,
+    /// Raise an interrupt upon overflow.
+    interrupt: Enable = .disable,
+    /// Enable the timer.
+    enable: Enable = .disable,
+    /// Unused bits.
+    unused_2: u8 = 0,
+};
+
+/// Corresponds to tonc REG_TM1D.
+/// Writing to this register does NOT set the current timer value.
+/// It sets the INITIAL timer value for the next timer run.
+pub const data_1: *volatile u16 = @ptrFromInt(gba.mem.io + 0x100);
+
+/// Corresponds to tonc REG_TM1CNT.
+pub const ctrl_1: *volatile timer.Control = @ptrFromInt(gba.mem.io + 0x102);
+
+/// Corresponds to tonc REG_TM2D.
+/// Writing to this register does NOT set the current timer value.
+/// It sets the INITIAL timer value for the next timer run.
+pub const data_2: *volatile u16 = @ptrFromInt(gba.mem.io + 0x104);
+
+/// Corresponds to tonc REG_TM2CNT.
+pub const ctrl_2: *volatile timer.Control = @ptrFromInt(gba.mem.io + 0x106);
+
+/// Corresponds to tonc REG_TM3D.
+/// Writing to this register does NOT set the current timer value.
+/// It sets the INITIAL timer value for the next timer run.
+pub const data_3: *volatile u16 = @ptrFromInt(gba.mem.io + 0x108);
+
+/// Corresponds to tonc REG_TM3CNT.
+pub const ctrl_3: *volatile timer.Control = @ptrFromInt(gba.mem.io + 0x10a);
+
+/// Corresponds to tonc REG_TM4D.
+/// Writing to this register does NOT set the current timer value.
+/// It sets the INITIAL timer value for the next timer run.
+pub const data_4: *volatile u16 = @ptrFromInt(gba.mem.io + 0x10c);
+
+/// Corresponds to tonc REG_TM4CNT.
+pub const ctrl_4: *volatile timer.Control = @ptrFromInt(gba.mem.io + 0x10e);

--- a/GBA/timer.zig
+++ b/GBA/timer.zig
@@ -65,4 +65,4 @@ pub const Timer = packed struct(u32) {
     _: u8 = 0,
 };
 
-pub const timer: *volatile [4]Timer align(4) = @ptrFromInt(gba.mem.io + 0x100);
+pub const timers: *volatile [4]Timer align(4) = @ptrFromInt(gba.mem.io + 0x100);

--- a/GBA/timer.zig
+++ b/GBA/timer.zig
@@ -22,7 +22,7 @@ pub const Timer = packed struct(u32) {
     };
 
     /// Represents the data of a REG_TMxCNT timer control register.
-    pub const Control = packed struct(u16) {
+    pub const Control = packed struct(u8) {
         /// Timer frequency.
         /// One second is equivalent to 1024 * 0x4000 clock cycles.
         freq: Timer.Frequency = .cycles_1,
@@ -30,23 +30,24 @@ pub const Timer = packed struct(u32) {
         /// when the previous timer overflows. (The timer must also be enabled.)
         cascade: Enable = .disable,
         /// Unused bits.
-        _1: u3 = 0,
+        _: u3 = 0,
         /// Raise an interrupt upon overflow.
         interrupt: Enable = .disable,
         /// Enable the timer.
         enable: Enable = .disable,
-        /// Unused bits.
-        _2: u8 = 0,
     };
     
     /// Corresponds to tonc REG_TMxD.
     /// Reading this register gives a timer's current elapsed intervals.
     /// Writing to this register does NOT set the current timer value.
     /// It sets the INITIAL timer value for the next timer run.
-    counter: u16,
+    counter: u16 = 0,
     
     /// Corresponds to tonc REG_TMxCNT.
-    ctrl: Timer.Control,
+    ctrl: Timer.Control = .{},
+    
+    /// Unused high bits of REG_TMxCNT.
+    _: u8 = 0,
 };
 
 pub const timer: *volatile [4]Timer align(4) = @ptrFromInt(gba.mem.io + 0x100);

--- a/GBA/timer.zig
+++ b/GBA/timer.zig
@@ -5,10 +5,21 @@ const Enable = gba.utils.Enable;
 /// Encapsulates access to REG_TMxD and REG_TMxCNT registers
 /// for controlling and reading one of the GBA's four timers.
 pub const Timer = packed struct(u32) {
+    /// Enumeration of possible counting modes for a timer.
+    pub const Mode = enum(u1) {
+        /// The timer counter advances once per N cycles, where N
+        /// is decided by the timer control register's frequency setting.
+        freq,
+        /// The timer counter advances when the previous, lower-numbered
+        /// timer counter overflows.
+        cascade,
+    };
+    
     /// Enumeration of recognized timer tick frequencies.
     pub const Frequency = enum(u2) {
         /// One timer tick per clock cycle.
-        /// Equivalent to 1/16777216th second, or approximately 0.06 microseconds.
+        /// Equivalent to 1/16777216th second, or approximately 0.06
+        /// microseconds.
         cycles_1 = 0,
         /// One timer tick per 64 clock cycles.
         /// Equivalent to 1/262144th second, or approximately 3.8 microseconds.
@@ -25,10 +36,14 @@ pub const Timer = packed struct(u32) {
     pub const Control = packed struct(u8) {
         /// Timer frequency.
         /// One second is equivalent to 1024 * 0x4000 clock cycles.
+        /// This field is only used when the mode is not "cascade".
         freq: Timer.Frequency = .cycles_1,
-        /// Cascade mode. When this bit is set, this timer will be incremented
-        /// when the previous timer overflows. (The timer must also be enabled.)
-        cascade: Enable = .disable,
+        /// Indicate under what circumstances the timer counter should
+        /// increment.
+        /// In cascade mode, the freq field is ignored, and the timer
+        /// is incremented as the previous timer overflows.
+        /// (The timer must also be enabled for this to happen.)
+        mode: Timer.Mode = .freq,
         /// Unused bits.
         _: u3 = 0,
         /// Raise an interrupt upon overflow.

--- a/GBA/timer.zig
+++ b/GBA/timer.zig
@@ -30,13 +30,13 @@ pub const Timer = packed struct(u32) {
         /// when the previous timer overflows. (The timer must also be enabled.)
         cascade: Enable = .disable,
         /// Unused bits.
-        unused_1: u3 = 0,
+        _1: u3 = 0,
         /// Raise an interrupt upon overflow.
         interrupt: Enable = .disable,
         /// Enable the timer.
         enable: Enable = .disable,
         /// Unused bits.
-        unused_2: u8 = 0,
+        _2: u8 = 0,
     };
     
     /// Corresponds to tonc REG_TMxD.

--- a/build.zig
+++ b/build.zig
@@ -6,6 +6,7 @@ pub fn build(b: *std.Build) void {
     _ = GBABuilder.addGBAExecutable(b, "mode3draw", "examples/mode3draw/mode3draw.zig");
     _ = GBABuilder.addGBAExecutable(b, "mode4draw", "examples/mode4draw/mode4draw.zig");
     _ = GBABuilder.addGBAExecutable(b, "debugPrint", "examples/debugPrint/debugPrint.zig");
+    _ = GBABuilder.addGBAExecutable(b, "secondsTimer", "examples/secondsTimer/secondsTimer.zig");
 
     // Mode 4 Flip
     const mode4flip = GBABuilder.addGBAExecutable(b, "mode4flip", "examples/mode4flip/mode4flip.zig");

--- a/examples/secondsTimer/secondsTimer.zig
+++ b/examples/secondsTimer/secondsTimer.zig
@@ -94,8 +94,7 @@ pub fn main() void {
     timer[2] = .{
         .counter = 0,
         .ctrl = .{
-            .freq = .cycles_1024,
-            .cascade = .enable,
+            .mode = .cascade,
             .enable = .enable,
         },
     };

--- a/examples/secondsTimer/secondsTimer.zig
+++ b/examples/secondsTimer/secondsTimer.zig
@@ -1,0 +1,108 @@
+const gba = @import("gba");
+const display = gba.display;
+const bg = gba.bg;
+const timer = gba.timer;
+const bios = gba.bios;
+
+export var gameHeader linksection(".gbaheader") = gba.initHeader("SECSTIMER", "ASBE", "00", 0);
+
+fn initMap() void {
+    // Init background
+    bg.ctrl[0] = .{
+        .screen_base_block = 28,
+        .tile_map_size = .{ .normal = .@"32x32" },
+    };
+    bg.scroll[0].set(0, 0);
+
+    // Create tiles for numeric digits
+    bg.tile_ram[0][0] = @bitCast([_]u32{
+        0x11111110, 0x11000110, 0x11000110, 0x11000110,
+        0x11000110, 0x11000110, 0x11111110, 0x00000000,
+    });
+    bg.tile_ram[0][1] = @bitCast([_]u32{
+        0x11000000, 0x11000000, 0x11000000, 0x11000000,
+        0x11000000, 0x11000000, 0x11000000, 0x00000000,
+    });
+    bg.tile_ram[0][2] = @bitCast([_]u32{
+        0x11111110, 0x11000000, 0x11000000, 0x11111110,
+        0x00000110, 0x00000110, 0x11111110, 0x00000000,
+    });
+    bg.tile_ram[0][3] = @bitCast([_]u32{
+        0x11111110, 0x11000000, 0x11000000, 0x11111110,
+        0x11000000, 0x11000000, 0x11111110, 0x00000000,
+    });
+    bg.tile_ram[0][4] = @bitCast([_]u32{
+        0x11000110, 0x11000110, 0x11000110, 0x11111110,
+        0x11000000, 0x11000000, 0x11000000, 0x00000000,
+    });
+    bg.tile_ram[0][5] = @bitCast([_]u32{
+        0x11111110, 0x00000110, 0x00000110, 0x11111110,
+        0x11000000, 0x11000000, 0x11111110, 0x00000000,
+    });
+    bg.tile_ram[0][6] = @bitCast([_]u32{
+        0x11111110, 0x00000110, 0x00000110, 0x11111110,
+        0x11000110, 0x11000110, 0x11111110, 0x00000000,
+    });
+    bg.tile_ram[0][7] = @bitCast([_]u32{
+        0x11111110, 0x11000000, 0x11000000, 0x11000000,
+        0x11000000, 0x11000000, 0x11000000, 0x00000000,
+    });
+    bg.tile_ram[0][8] = @bitCast([_]u32{
+        0x11111110, 0x11000110, 0x11000110, 0x11111110,
+        0x11000110, 0x11000110, 0x11111110, 0x00000000,
+    });
+    bg.tile_ram[0][9] = @bitCast([_]u32{
+        0x11111110, 0x11000110, 0x11000110, 0x11111110,
+        0x11000000, 0x11000000, 0x11111110, 0x00000000,
+    });
+    bg.tile_ram[0][10] = @bitCast([_]u32{
+        0x00000000, 0x00000000, 0x00000000, 0x00000000,
+        0x00000000, 0x00000000, 0x00000000, 0x00000000,
+    });
+
+    // Initialize a palette
+    const bg_palette = &bg.palette.banks;
+    bg_palette[0][1] = gba.Color.rgb(31, 31, 31);
+    
+    // Initialize the map to all blank tiles
+    const bg0_map: [*]volatile bg.TextScreenEntry = @ptrCast(&bg.screen_block_ram[28]);
+    for (0..32*32) |map_index| {
+        bg0_map[map_index].palette_index = 0;
+        bg0_map[map_index].tile_index = 10;
+    }
+}
+
+pub fn main() void {
+    initMap();
+    display.ctrl.* = .{
+        .bg0 = .enable,
+        .obj = .enable,
+    };
+    
+    // Based on the example here: https://gbadev.net/tonc/timers.html
+    // Timer 1 will overflow every 0x4000 * 1024 clock cycles,
+    // which is the same as once per second.
+    // When it oveflows, Timer 2 will be incremented by 1 due
+    // to its "cascade" flag.
+    timer.data_1.* = @truncate(-0x4000);
+    timer.ctrl_1.* = .{
+        .freq = .cycles_1024,
+        .enable = .enable,
+    };
+    timer.ctrl_2.* = .{
+        .freq = .cycles_1024,
+        .cascade = .enable,
+        .enable = .enable,
+    };
+    
+    const bg0_map: [*]volatile bg.TextScreenEntry = @ptrCast(&bg.screen_block_ram[28]);
+    
+    while (true) {
+        display.naiveVSync();
+        
+        // Convert elapsed seconds to a 2-digit display
+        const digits = bios.div(timer.data_2.*, 10);
+        bg0_map[33].tile_index = @intCast(digits.division);
+        bg0_map[34].tile_index = @intCast(digits.remainder);
+    }
+}

--- a/examples/secondsTimer/secondsTimer.zig
+++ b/examples/secondsTimer/secondsTimer.zig
@@ -4,7 +4,7 @@ const bg = gba.bg;
 const timer = gba.timer;
 const bios = gba.bios;
 
-export var gameHeader linksection(".gbaheader") = gba.initHeader("SECSTIMER", "ASBE", "00", 0);
+export const gameHeader linksection(".gbaheader") = gba.initHeader("SECSTIMER", "ASBE", "00", 0);
 
 fn initMap() void {
     // Init background
@@ -84,12 +84,12 @@ pub fn main() void {
     // which is the same as once per second.
     // When it oveflows, Timer 2 will be incremented by 1 due
     // to its "cascade" flag.
-    timer.data_1.* = @truncate(-0x4000);
-    timer.ctrl_1.* = .{
+    timer[1].data = @truncate(-0x4000);
+    timer[1].ctrl = .{
         .freq = .cycles_1024,
         .enable = .enable,
     };
-    timer.ctrl_2.* = .{
+    timer[2].ctrl = .{
         .freq = .cycles_1024,
         .cascade = .enable,
         .enable = .enable,
@@ -101,7 +101,7 @@ pub fn main() void {
         display.naiveVSync();
         
         // Convert elapsed seconds to a 2-digit display
-        const digits = bios.div(timer.data_2.*, 10);
+        const digits = bios.div(timer[2].data, 10);
         bg0_map[33].tile_index = @intCast(digits.division);
         bg0_map[34].tile_index = @intCast(digits.remainder);
     }

--- a/examples/secondsTimer/secondsTimer.zig
+++ b/examples/secondsTimer/secondsTimer.zig
@@ -84,7 +84,7 @@ pub fn main() void {
     // which is the same as once per second.
     // When it oveflows, Timer 2 will be incremented by 1 due
     // to its "cascade" flag.
-    timer[1].data = @truncate(-0x4000);
+    timer[1].counter = @truncate(-0x4000);
     timer[1].ctrl = .{
         .freq = .cycles_1024,
         .enable = .enable,
@@ -101,7 +101,7 @@ pub fn main() void {
         display.naiveVSync();
         
         // Convert elapsed seconds to a 2-digit display
-        const digits = bios.div(timer[2].data, 10);
+        const digits = bios.div(timer[2].counter, 10);
         bg0_map[33].tile_index = @intCast(digits.division);
         bg0_map[34].tile_index = @intCast(digits.remainder);
     }

--- a/examples/secondsTimer/secondsTimer.zig
+++ b/examples/secondsTimer/secondsTimer.zig
@@ -1,14 +1,15 @@
 const gba = @import("gba");
 const display = gba.display;
 const bg = gba.bg;
-const timer = gba.timer;
+const Timer = gba.timer.Timer;
+const timers = gba.timer.timers;
 const bios = gba.bios;
 
 export const gameHeader linksection(".gbaheader") = gba.initHeader("SECSTIMER", "ASBE", "00", 0);
 
 fn initMap() void {
     // Init background
-    bg.ctrl[0] = .{
+    bg.ctrl[0] = bg.Control {
         .screen_base_block = 28,
         .tile_map_size = .{ .normal = .@"32x32" },
     };
@@ -74,7 +75,7 @@ fn initMap() void {
 
 pub fn main() void {
     initMap();
-    display.ctrl.* = .{
+    display.ctrl.* = display.Control {
         .bg0 = .enable,
         .obj = .enable,
     };
@@ -84,14 +85,14 @@ pub fn main() void {
     // which is the same as once per second.
     // When it oveflows, Timer 2 will be incremented by 1 due
     // to its "cascade" flag.
-    timer[1] = .{
+    timers[1] = Timer {
         .counter = @truncate(-0x4000),
         .ctrl = .{
             .freq = .cycles_1024,
             .enable = .enable,
         },
     };
-    timer[2] = .{
+    timers[2] = Timer {
         .counter = 0,
         .ctrl = .{
             .mode = .cascade,
@@ -105,7 +106,7 @@ pub fn main() void {
         display.naiveVSync();
         
         // Convert elapsed seconds to a 2-digit display
-        const digits = bios.div(timer[2].counter, 10);
+        const digits = bios.div(timers[2].counter, 10);
         bg0_map[33].tile_index = @intCast(digits.division);
         bg0_map[34].tile_index = @intCast(digits.remainder);
     }

--- a/examples/secondsTimer/secondsTimer.zig
+++ b/examples/secondsTimer/secondsTimer.zig
@@ -84,15 +84,20 @@ pub fn main() void {
     // which is the same as once per second.
     // When it oveflows, Timer 2 will be incremented by 1 due
     // to its "cascade" flag.
-    timer[1].counter = @truncate(-0x4000);
-    timer[1].ctrl = .{
-        .freq = .cycles_1024,
-        .enable = .enable,
+    timer[1] = .{
+        .counter = @truncate(-0x4000),
+        .ctrl = .{
+            .freq = .cycles_1024,
+            .enable = .enable,
+        },
     };
-    timer[2].ctrl = .{
-        .freq = .cycles_1024,
-        .cascade = .enable,
-        .enable = .enable,
+    timer[2] = .{
+        .counter = 0,
+        .ctrl = .{
+            .freq = .cycles_1024,
+            .cascade = .enable,
+            .enable = .enable,
+        },
     };
     
     const bg0_map: [*]volatile bg.TextScreenEntry = @ptrCast(&bg.screen_block_ram[28]);


### PR DESCRIPTION
Add a `timer.zig` module which exposes an API for setting and reading timer-related registers.

Disclaimer: I have basically no idea what I'm doing. Hopefully this is sensible?

Based on the documentation here: https://gbadev.net/tonc/timers.html

(This PR was based on the same `builder.zig` changes as in #24, which were needed for me to build ziggba with a recent version of zig.)