### PR TITLE
Draft: Make compatible with zig 0.14.1

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,13 @@
+.{
+    .name = .ziggba,
+    .version = "0.0.0",
+    .fingerprint = 0x94ed0cc5e826ab7, // Changing this has security and trust implications.
+    .minimum_zig_version = "0.14.1",
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "GBA",
+        "LICENSE",
+        "README.md",
+    },
+}


### PR DESCRIPTION
Blocked by #27

This allows all examples in the repository to be built with 0.14.0+, though the built ROMs have junk code at the entry point due to some change in how the inline assembly of the `_start` function in `gba.zig` is compiled, that will also need to be fixed.

The ROMs compiled with this branch can still be run with NanoBoyAdvance, due to that emulator not correctly implementing stop mode. (Which causes a well-behaved emulator to immediately quit running the game.) It can also be run with mGBA by attempting to run the ROM once, then attempting to run it again from the automatically created save state.
