### PR TITLE
Fix #30 - Compilation error when .text section is too large

### DIFF
--- a/GBA/gba.zig
+++ b/GBA/gba.zig
@@ -123,12 +123,18 @@ export fn _start() noreturn {
         \\
         \\mov r0, #0x12
         \\msr cpsr, r0
-        \\ldr sp, =__sp_irq
+        \\ldr sp, _start_sp_irq_word
         \\mov r0, #0x1f
         \\msr cpsr, r0
-        \\ldr sp, =__sp_usr
-        \\add r0, pc, #1
+        \\ldr sp, _start_sp_usr_word
+        \\adr r0, #1 + _start_zig
         \\bx r0
+        // Ensure _sq_irq and _sq_usr are defined near enough
+        // to the entry point to be referenced with `ldr` above.
+        \\  .align 4
+        \\_start_sp_irq_word: .word __sp_irq
+        \\_start_sp_usr_word: .word __sp_usr
+        \\_start_zig:
     );
 
     // Use BIOS function to clear all data


### PR DESCRIPTION
Fixes #30

Reference: https://feuniverse.us/t/gba-start-routine-and-global-variables-initialization/4902

Assuming I've understood the issue correctly: If these words are not placed in memory near the inline asm here, then `ldr` fails after the size of compiled zig code exceeds ~4kb, in which case the address of __sp_irq and __sp_usr become too distant from the entry point code for the offset to fit into the ldr instruction's unsigned 12 bit immediate.

http://bear.ces.cwru.edu/eecs_382/ARM7-TDMI-manual-pt2.pdf

![image](https://github.com/user-attachments/assets/23b8e1c9-52f5-4bd1-af20-2a1b8ff8bffb)

